### PR TITLE
Change esx_society function to get firstname,lastname from users table instead of characters table when using Config.EnableESXIdentity

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -203,7 +203,7 @@ ESX.RegisterServerCallback('esx_society:getEmployees', function(source, cb, soci
 
   if Config.EnableESXIdentity then
     MySQL.Async.fetchAll(
-      'SELECT characters.*, users.job, users.job_grade FROM characters JOIN users ON characters.identifier = users.identifier WHERE users.job = @job ORDER BY users.job_grade DESC',
+      'SELECT * FROM users WHERE job = @job ORDER BY job_grade DESC',
       { ['@job'] = society },
       function (results)
         local employees = {}


### PR DESCRIPTION
If someone wants to make this change themselves, please cancel this pull request. I just thought I would save some time for everyone and go ahead and alter it while I was altering the rest.