### PR TITLE
Update main.lua Money Gitch Patched (line 388 )

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -387,6 +387,8 @@ function OpenManageGradesMenu(society)
 
             if amount == nil then
               ESX.ShowNotification(_U('invalid_amount'))
+            elseif amount >= 3001 then
+              ESX.ShowNotification(_U('invalid_amount_max'))
             else
               menu2.close()
 


### PR DESCRIPTION
## Money Glitch Patch
Added Fix for salary, this patch fix the issue that **the boss can change his salary to 100000000** or any other emplyee and actually get the money when the **paycheck is given** , now the limit is **3000 (max salary input)** but you can always change it at the line **390**.
Dont forget to add in locals folder at your language a new line , that translate : **invalid_amount_max** .